### PR TITLE
add export stubs in a `cjs-module-lexer`-friendly way

### DIFF
--- a/rsc.js
+++ b/rsc.js
@@ -1,71 +1,89 @@
 // @ts-check
-const React = require("react");
 
-const GuaranteedReactExports = [
-  "Children",
-  "Component",
-  "Fragment",
-  "Profiler",
-  "PureComponent",
-  "StrictMode",
-  "Suspense",
-  "cache",
-  "cloneElement",
+// cjs-module-lexer will let all of react's (named) exports through unchanged.
+module.exports = { ...require("react") };
+
+const missingFunctions = [
   "createContext",
-  "createElement",
   "createFactory",
-  "createRef",
-  "createServerContext",
-  "forwardRef",
-  "isValidElement",
-  "lazy",
-  "memo",
-  "startTransition",
+  "act",
   "unstable_act",
   "unstable_useCacheRefresh",
-  "use",
-  "useCallback",
   "useContext",
-  "useDebugValue",
   "useDeferredValue",
   "useEffect",
-  "useId",
   "useImperativeHandle",
   "useInsertionEffect",
   "useLayoutEffect",
-  "useMemo",
   "useReducer",
   "useRef",
   "useState",
   "useSyncExternalStore",
   "useTransition",
-  "version",
+  "useOptimistic",
 ];
 
-const Polyfilled = {
-  ...Object.fromEntries(
-    Object.values(GuaranteedReactExports).map((exportName) => [
-      exportName,
-      function throwOnNonExistentImport() {
-        throw new Error(
-          `React functionality ${exportName} is not available in this environment.`
-        );
-      },
-    ])
-  ),
-  // @ts-expect-error we want `createContext` to be executable in RSC
-  // the created empty context object cannot be used in any meaningful way
-  // but this can keep consuming libraries that create a context from
-  // crashing on import
-  createContext: () => ({
+const missingClasses = ["Component", "PureComponent"];
+
+missingFunctions.forEach((exportName) => {
+  module.exports[exportName] ||= function throwOnNonExistentImport() {
+    throw new Error(
+      `React functionality '${exportName}' is not available in this environment.`
+    );
+  };
+});
+
+missingClasses.forEach((exportName) => {
+  module.exports[exportName] ||= class NonExistentClass {
+    constructor() {
+      throw new Error(
+        `React class '${exportName}' is not available in this environment.`
+      );
+    }
+  };
+});
+
+module.exports.createContext ||= function unsupportedCreateContext() {
+  return {
     Provider: function throwNoContext() {
       throw new Error("Context is not available in this environment.");
     },
     Consumer: function throwNoContext() {
       throw new Error("Context is not available in this environment.");
     },
-  }),
-  ...React,
+  };
 };
 
-module.exports = Polyfilled;
+module.exports.createFactory ||= function unsupportedCreateFactory() {
+  return function throwNoCreateFactory() {
+    throw new Error("createFactory is not available in this environment.");
+  };
+};
+
+// Trick cjs-module-lexer into adding named exports for these names.
+// (they will appear in `.default` as well.)
+// NOTE: these names need to appear verbatim, no variables or anything!
+if (0) {
+  const DUMMY = /** @type {any} */ (1);
+  // missingFunctions
+  module.exports.createContext = DUMMY;
+  module.exports.createFactory = DUMMY;
+  module.exports.act = DUMMY;
+  module.exports.unstable_act = DUMMY;
+  module.exports.unstable_useCacheRefresh = DUMMY;
+  module.exports.useContext = DUMMY;
+  module.exports.useDeferredValue = DUMMY;
+  module.exports.useEffect = DUMMY;
+  module.exports.useImperativeHandle = DUMMY;
+  module.exports.useInsertionEffect = DUMMY;
+  module.exports.useLayoutEffect = DUMMY;
+  module.exports.useReducer = DUMMY;
+  module.exports.useRef = DUMMY;
+  module.exports.useState = DUMMY;
+  module.exports.useSyncExternalStore = DUMMY;
+  module.exports.useTransition = DUMMY;
+  module.exports.useOptimistic = DUMMY;
+  // missingClasses
+  module.exports.Component = DUMMY;
+  module.exports.PureComponent = DUMMY;
+}


### PR DESCRIPTION
This approach is more resilient to changes in React, because we're only adding the exports we want to stub, meaning that this doesn't need to get updated every time react adds a new API -- we only need to touch this when a new *client-only* API is added. In addition, adding fake `module.exports.foo` assignments makes this `cjs-module-lexer`-friendly, so we get nice named exports for these (while also preserving any exports coming from React).