### PR TITLE
Make peerDependencies match RSC versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "README.md"
   ],
   "peerDependencies": {
-    "react": "*",
-    "@types/react": "*"
+    "react": ">=18.2.0",
+    "@types/react": ">=18.2.57"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
Hi @phryneas, thanks for the work you've put into making the Apollo packages work with RSC, amazing!

Just wanted to do a quick PR to set a minimum version for the `react` and `@types/react` peer deps (`peerDependencies` are installed by pnpm and npm)

This avoids situations where pnpm will resolve `@types/react` to the lowest possible common denominator, leading to a `pnpm-lock.yaml` in a Next.js project like this (`@types/react@18.0.0` was installed):

```yaml
dependencies:
  '@apollo/client':
    specifier: ^3.9.5
    version: 3.9.5(@types/react@18.0.0)(graphql@16.8.1)(react-dom@18.0.0)(react@18.0.0)
```

@Eprince-hub had this during one of our lectures, and it caused the types for `cache` and other later React features to break.