### PR TITLE
Add `undefined` exports for potentially missing React internals.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,24 @@
 "use strict";
-module.exports = require("react");
+if (0) {
+  // Trick cjs-module-lexer into adding named exports for all React exports.
+  // (if imported with `import()`, they will appear in `.default` as well.)
+  // This way, cjs-module-lexer will let all of react's (named) exports through unchanged.
+  module.exports = require("react");
+}
+// We don't want bundlers to error when they encounter usage of any of these exports
+// it's up to the package author to ensure that if they access React internals,
+// they do so in a safe way that won't break if React changes how they use these internals.
+// (e.g. only access them in development, and only in an optional way that won't
+// break if internals are not there or do not have the expected structure)
+// @ts-ignore
+module.exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = undefined;
+// @ts-ignore
+module.exports.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = undefined;
+// @ts-ignore
+module.exports.__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = undefined;
+// Here we actually pull in the React library and add everything
+// it exports to our own `module.exports`.
+// If React suddenly were to add one of the above "polyfilled" exports,
+// the React version would overwrite our version, so this should be
+// future-proof.
+Object.assign(module.exports, require("react"));

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ if (0) {
   // This way, cjs-module-lexer will let all of react's (named) exports through unchanged.
   module.exports = require("react");
 }
-// We don't want bundlers to error when they encounter usage of any of these exports
-// it's up to the package author to ensure that if they access React internals,
+// We don't want bundlers to error when they encounter usage of any of these exports.
+// It's up to the package author to ensure that if they access React internals,
 // they do so in a safe way that won't break if React changes how they use these internals.
 // (e.g. only access them in development, and only in an optional way that won't
 // break if internals are not there or do not have the expected structure)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "rehackt",
-  "version": "0.0.2",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehackt",
-      "version": "0.0.2",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.5.7",
-        "react": "^18.3.0-canary-ab31a9ed2-20230824"
+        "react": "^19.0.0-canary-33a32441e9-20240418"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -31,32 +31,11 @@
       "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
       "dev": true
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/react": {
-      "version": "18.3.0-canary-ab31a9ed2-20230824",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0-canary-ab31a9ed2-20230824.tgz",
-      "integrity": "sha512-HD+uBKLoOvI0aRUjpxj6w5El7fit6m/8/WFtsqkfcjDHuFAWl5CGa9Xp9CtKwZgl+Aali9SOj+fgt0aTar5Hhg==",
+      "version": "19.0.0-canary-33a32441e9-20240418",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-canary-33a32441e9-20240418.tgz",
+      "integrity": "sha512-daCqNhSLKCDulgZJ/ER4bvsErZmKjRkDtcepxmpb/P0S2VgrFLHNJi8oUdMuZkAkXuo1EF+h41JSs567iBPDsA==",
       "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehackt",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehackt",
-      "version": "0.0.6",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.5.7",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "LICENSE.md"
   ],
   "peerDependencies": {
-    "react": "*",
-    "@types/react": "*"
+    "@types/react": "*",
+    "react": "*"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -39,8 +39,8 @@
     }
   },
   "devDependencies": {
-    "react": "^18.3.0-canary-ab31a9ed2-20230824",
-    "@types/node": "^20.5.7"
+    "@types/node": "^20.5.7",
+    "react": "^19.0.0-canary-33a32441e9-20240418"
   },
   "prettier": {
     "printWidth": 120

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehackt",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "A wrapper around React that will hide hooks from the React Server Component compiler",
   "author": "Lenz Weber-Tronic",
   "repository": {

--- a/rsc.js
+++ b/rsc.js
@@ -27,8 +27,8 @@ module.exports.useState = polyfillMissingFn("useState");
 module.exports.useSyncExternalStore = polyfillMissingFn("useSyncExternalStore");
 module.exports.useTransition = polyfillMissingFn("useTransition");
 module.exports.useOptimistic = polyfillMissingFn("useOptimistic");
-// We don't want bundlers to error when they encounter usage of any of these exports
-// it's up to the package author to ensure that if they access React internals,
+// We don't want bundlers to error when they encounter usage of any of these exports.
+// It's up to the package author to ensure that if they access React internals,
 // they do so in a safe way that won't break if React changes how they use these internals.
 // (e.g. only access them in development, and only in an optional way that won't
 // break if internals are not there or do not have the expected structure)

--- a/rsc.js
+++ b/rsc.js
@@ -9,8 +9,10 @@ if (0) {
 
 // missing functions
 module.exports.createContext = polyfillMissingFn("createContext");
+// @ts-ignore
 module.exports.createFactory = polyfillMissingFn("createFactory");
 module.exports.act = polyfillMissingFn("act");
+// @ts-ignore
 module.exports.unstable_act = polyfillMissingFn("unstable_act");
 module.exports.unstable_useCacheRefresh = polyfillMissingFn("unstable_useCacheRefresh");
 module.exports.useContext = polyfillMissingFn("useContext");
@@ -25,6 +27,17 @@ module.exports.useState = polyfillMissingFn("useState");
 module.exports.useSyncExternalStore = polyfillMissingFn("useSyncExternalStore");
 module.exports.useTransition = polyfillMissingFn("useTransition");
 module.exports.useOptimistic = polyfillMissingFn("useOptimistic");
+// We don't want bundlers to error when they encounter usage of any of these exports
+// it's up to the package author to ensure that if they access React internals,
+// they do so in a safe way that won't break if React changes how they use these internals.
+// (e.g. only access them in development, and only in an optional way that won't
+// break if internals are not there or do not have the expected structure)
+// @ts-ignore
+module.exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = undefined;
+// @ts-ignore
+module.exports.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = undefined;
+// @ts-ignore
+module.exports.__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = undefined;
 
 // missing classes
 module.exports.Component = polyfillMissingClass("Component");
@@ -40,7 +53,7 @@ module.exports.createContext = function unsupportedCreateContext() {
     },
   };
 };
-
+// @ts-ignore
 module.exports.createFactory = function unsupportedCreateFactory() {
   return function throwNoCreateFactory() {
     throw new Error("createFactory is not available in this environment.");


### PR DESCRIPTION
We don't want bundlers to error when they encounter usage of any of these exports.
It's up to the package author to ensure that if they access React internals,
they do so in a safe way that won't break if React changes how they use these internals.
(e.g. only access them in development, and only in an optional way that won't
break if internals are not there or do not have the expected structure).